### PR TITLE
Add profiling flags to ringpong

### DIFF
--- a/step2/tests/CMakeLists.txt
+++ b/step2/tests/CMakeLists.txt
@@ -1,3 +1,4 @@
+set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} -pg")
 add_executable(edgetest edgetest.c)
 target_link_libraries(edgetest PUBLIC zhpeq zhpeq_util)
 


### PR DESCRIPTION
In order to get an overview of the call stack, we'll use gprof. Thus, profile symbols are required.